### PR TITLE
Mixin Plugin Configuration Fix

### DIFF
--- a/api/src/main/java/com/mineteria/ignite/api/Blackboard.java
+++ b/api/src/main/java/com/mineteria/ignite/api/Blackboard.java
@@ -33,7 +33,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
-public final class IgniteBlackboard {
+public final class Blackboard {
   private static final BlackboardMap BLACKBOARD = new BlackboardMap();
 
   public static final BlackboardMap.@NonNull Key<List<String>> LAUNCH_ARGUMENTS = key("ignite.launch.arguments", new TypeToken<List<String>>() {});
@@ -44,18 +44,18 @@ public final class IgniteBlackboard {
   public static final BlackboardMap.@NonNull Key<Path> CONFIG_DIRECTORY_PATH    = key("ignite.config.directory", TypeToken.of(Path.class));
 
   public static <T> @Nullable T getProperty(final BlackboardMap.@NonNull Key<T> key) {
-    return IgniteBlackboard.getProperty(key, null);
+    return Blackboard.BLACKBOARD.get(key).orElse(null);
   }
 
-  public static <T> @Nullable T getProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T defaultValue) {
-    return IgniteBlackboard.BLACKBOARD.get(key).orElse(defaultValue);
+  public static <T> @NonNull T getProperty(final BlackboardMap.@NonNull Key<T> key, final @NonNull T defaultValue) {
+    return Blackboard.BLACKBOARD.get(key).orElse(defaultValue);
   }
 
-  public static <T> void setProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T value) {
-    IgniteBlackboard.BLACKBOARD.computeIfAbsent(key, k -> value);
+  public static <T> @Nullable T setProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T value) {
+    return Blackboard.BLACKBOARD.computeIfAbsent(key, k -> value);
   }
 
   private static <T> BlackboardMap.@NonNull Key<T> key(final @NonNull String key, final @NonNull TypeToken<T> type) {
-    return BlackboardMap.Key.getOrCreate(IgniteBlackboard.BLACKBOARD, key, type.getRawType());
+    return BlackboardMap.Key.getOrCreate(Blackboard.BLACKBOARD, key, type.getRawType());
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/Ignite.java
+++ b/api/src/main/java/com/mineteria/ignite/api/Ignite.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api;
 
 import com.google.inject.Inject;

--- a/api/src/main/java/com/mineteria/ignite/api/IgniteBlackboard.java
+++ b/api/src/main/java/com/mineteria/ignite/api/IgniteBlackboard.java
@@ -22,10 +22,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.mineteria.ignite.applaunch;
+package com.mineteria.ignite.api;
 
 import com.google.common.reflect.TypeToken;
-import cpw.mods.modlauncher.api.TypesafeMap;
+import com.mineteria.ignite.api.util.BlackboardMap;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -34,28 +34,28 @@ import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
 public final class IgniteBlackboard {
-  private static final TypesafeMap BLACKBOARD = new TypesafeMap();
+  private static final BlackboardMap BLACKBOARD = new BlackboardMap();
 
-  public static final TypesafeMap.@NonNull Key<List<String>> LAUNCH_ARGUMENTS = key("ignite.launch.arguments", new TypeToken<List<String>>() {});
-  public static final TypesafeMap.@NonNull Key<Path>         LAUNCH_JAR       = key("ignite.launch.jar", TypeToken.of(Path.class));
-  public static final TypesafeMap.@NonNull Key<String>       LAUNCH_TARGET    = key("ignite.launch.target", TypeToken.of(String.class));
+  public static final BlackboardMap.@NonNull Key<List<String>> LAUNCH_ARGUMENTS = key("ignite.launch.arguments", new TypeToken<List<String>>() {});
+  public static final BlackboardMap.@NonNull Key<Path>         LAUNCH_JAR       = key("ignite.launch.jar", TypeToken.of(Path.class));
+  public static final BlackboardMap.@NonNull Key<String>       LAUNCH_TARGET    = key("ignite.launch.target", TypeToken.of(String.class));
 
-  public static final TypesafeMap.@NonNull Key<Path> MOD_DIRECTORY_PATH = key("ignite.mod.directory", TypeToken.of(Path.class));
-  public static final TypesafeMap.@NonNull Key<Path> CONFIG_DIRECTORY_PATH = key("ignite.config.directory", TypeToken.of(Path.class));
+  public static final BlackboardMap.@NonNull Key<Path> MOD_DIRECTORY_PATH       = key("ignite.mod.directory", TypeToken.of(Path.class));
+  public static final BlackboardMap.@NonNull Key<Path> CONFIG_DIRECTORY_PATH    = key("ignite.config.directory", TypeToken.of(Path.class));
 
-  public static <T> @Nullable T getProperty(final TypesafeMap.@NonNull Key<T> key) {
+  public static <T> @Nullable T getProperty(final BlackboardMap.@NonNull Key<T> key) {
     return IgniteBlackboard.getProperty(key, null);
   }
 
-  public static <T> @Nullable T getProperty(final TypesafeMap.@NonNull Key<T> key, final @Nullable T defaultValue) {
+  public static <T> @Nullable T getProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T defaultValue) {
     return IgniteBlackboard.BLACKBOARD.get(key).orElse(defaultValue);
   }
 
-  public static <T> void setProperty(final TypesafeMap.@NonNull Key<T> key, final @Nullable T value) {
+  public static <T> void setProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T value) {
     IgniteBlackboard.BLACKBOARD.computeIfAbsent(key, k -> value);
   }
 
-  private static <T> TypesafeMap.@NonNull Key<T> key(final @NonNull String key, final @NonNull TypeToken<T> type) {
-    return TypesafeMap.Key.getOrCreate(IgniteBlackboard.BLACKBOARD, key, type.getRawType());
+  private static <T> BlackboardMap.@NonNull Key<T> key(final @NonNull String key, final @NonNull TypeToken<T> type) {
+    return BlackboardMap.Key.getOrCreate(IgniteBlackboard.BLACKBOARD, key, type.getRawType());
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/Platform.java
+++ b/api/src/main/java/com/mineteria/ignite/api/Platform.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api;
 
 import com.mineteria.ignite.api.event.EventManager;

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.config;
 
 import ninja.leaping.configurate.ConfigurationNode;
@@ -10,7 +34,16 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
+import java.util.Objects;
 
+/**
+ * A configuration wrapper to assist in managing the configuration
+ * loader and object mapper instance.
+ *
+ * @param <T> The object mapper instance type
+ * @param <N> The configuration node type
+ */
+@SuppressWarnings("unchecked")
 public final class Configuration<T, N extends ConfigurationNode> {
   private static <T> ObjectMapper<T> createMapper(final T instance) {
     try {
@@ -20,22 +53,31 @@ public final class Configuration<T, N extends ConfigurationNode> {
     }
   }
 
+  private final ConfigurationKey key;
   private final @Nullable ConfigurationLoader<N> loader;
   private final ObjectMapper<T> mapper;
   private final T instance;
 
   private @MonotonicNonNull N node;
 
-  /* package */ Configuration(final @NonNull T instance) {
-    this(instance, null);
+  /* package */ Configuration(final @NonNull ConfigurationKey key, final @NonNull T instance) {
+    this(key, instance, null);
   }
 
-  /* package */ Configuration(final @NonNull T instance, final @Nullable ConfigurationLoader<N> loader) {
+  /* package */ Configuration(final @NonNull ConfigurationKey key, final @NonNull T instance, final @Nullable ConfigurationLoader<N> loader) {
     this.mapper = Configuration.createMapper(instance);
+    this.key = key;
     this.instance = instance;
     this.loader = loader;
   }
 
+  /**
+   * Loads the configuration from the {@link ConfigurationLoader} if
+   * it exists.
+   *
+   * @throws IOException If the directory or file could not be created
+   * @throws ObjectMappingException If the instance could not be populated
+   */
   public void load() throws IOException, ObjectMappingException {
     if (this.loader == null) return;
 
@@ -44,20 +86,70 @@ public final class Configuration<T, N extends ConfigurationNode> {
     this.save();
   }
 
+  /**
+   * Saves the configuration to the {@link ConfigurationLoader} if
+   * it exists.
+   *
+   * @throws IOException If the directory or file could not be created
+   * @throws ObjectMappingException If the instance could not be serialized to
+   */
   public void save() throws IOException, ObjectMappingException {
     if (this.loader == null) return;
-
     if (this.node == null) this.node = this.loader.createEmptyNode();
 
     this.mapper.bind(this.instance).serialize(this.node);
     this.loader.save(this.node);
   }
 
+  /**
+   * Returns the configuration key.
+   *
+   * @return The configuration key
+   */
+  public ConfigurationKey getKey() {
+    return this.key;
+  }
+
+  /**
+   * Returns the object mapper instance.
+   *
+   * @return The object mapper instance
+   */
   public @NonNull T getInstance() {
     return this.instance;
   }
 
+  /**
+   * Returns the configuration node.
+   *
+   * @return The configuration node
+   */
   public @MonotonicNonNull N getNode() {
     return this.node;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.loader, this.mapper, this.instance, this.node);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof Configuration)) return false;
+    final Configuration<?, ?> that = (Configuration<?, ?>) other;
+    return Objects.equals(this.loader, that.loader)
+      && Objects.equals(this.mapper, that.mapper)
+      && Objects.equals(this.instance, that.instance)
+      && Objects.equals(this.node, that.node);
+  }
+
+  @Override
+  public String toString() {
+    return "Configuration{loader=" + this.loader +
+      ", mapper=" + this.mapper +
+      ", instance=" + this.instance +
+      ", node=" + this.node +
+      "}";
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
@@ -53,9 +53,9 @@ public final class Configuration<T, N extends ConfigurationNode> {
     }
   }
 
-  private final ConfigurationKey key;
   private final @Nullable ConfigurationLoader<N> loader;
   private final ObjectMapper<T> mapper;
+  private final ConfigurationKey key;
   private final T instance;
 
   private @MonotonicNonNull N node;

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configuration.java
@@ -1,0 +1,63 @@
+package com.mineteria.ignite.api.config;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.DefaultObjectMapperFactory;
+import ninja.leaping.configurate.objectmapping.ObjectMapper;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.io.IOException;
+
+public final class Configuration<T, N extends ConfigurationNode> {
+  private static <T> ObjectMapper<T> createMapper(final T instance) {
+    try {
+      return DefaultObjectMapperFactory.getInstance().getMapper((Class<T>) instance.getClass());
+    } catch (final ObjectMappingException exception) {
+      throw new AssertionError(exception);
+    }
+  }
+
+  private final @Nullable ConfigurationLoader<N> loader;
+  private final ObjectMapper<T> mapper;
+  private final T instance;
+
+  private @MonotonicNonNull N node;
+
+  /* package */ Configuration(final @NonNull T instance) {
+    this(instance, null);
+  }
+
+  /* package */ Configuration(final @NonNull T instance, final @Nullable ConfigurationLoader<N> loader) {
+    this.mapper = Configuration.createMapper(instance);
+    this.instance = instance;
+    this.loader = loader;
+  }
+
+  public void load() throws IOException, ObjectMappingException {
+    if (this.loader == null) return;
+
+    this.node = this.loader.load();
+    this.mapper.bind(this.instance).populate(this.node);
+    this.save();
+  }
+
+  public void save() throws IOException, ObjectMappingException {
+    if (this.loader == null) return;
+
+    if (this.node == null) this.node = this.loader.createEmptyNode();
+
+    this.mapper.bind(this.instance).serialize(this.node);
+    this.loader.save(this.node);
+  }
+
+  public @NonNull T getInstance() {
+    return this.instance;
+  }
+
+  public @MonotonicNonNull N getNode() {
+    return this.node;
+  }
+}

--- a/api/src/main/java/com/mineteria/ignite/api/config/ConfigurationKey.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/ConfigurationKey.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.mineteria.ignite.api.config;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * A key to identify a specific {@link Configuration}.
+ */
+public final class ConfigurationKey {
+  public static @NonNull ConfigurationKey key(final @NonNull String id, final @NonNull Path path) {
+    return new ConfigurationKey(id, path);
+  }
+
+  private final String id;
+  private final Path path;
+
+  /* package */ ConfigurationKey(final @NonNull String id, final @Nullable Path path) {
+    this.id = id;
+    this.path = path;
+  }
+
+  /**
+   * The configuration identifier.
+   *
+   * @return The configuration identifier
+   */
+  public @NonNull String getId() {
+    return this.id;
+  }
+
+  /**
+   * The configuration path.
+   *
+   * @return The configuration path
+   */
+  public @MonotonicNonNull Path getPath() {
+    return this.path;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.id, this.path);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other) return true;
+    if (!(other instanceof ConfigurationKey)) return false;
+    final ConfigurationKey that = (ConfigurationKey) other;
+    return Objects.equals(this.id, that.id)
+      && Objects.equals(this.path, that.path);
+  }
+
+  @Override
+  public String toString() {
+    return "ConfigurationKey{id=" + this.id +
+      ", path=" + this.path +
+      "}";
+  }
+}

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.config;
 
 import ninja.leaping.configurate.ConfigurationNode;
@@ -6,21 +30,32 @@ import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
+@SuppressWarnings("unchecked")
 public final class Configurations {
-  public static <T> @NonNull Configuration<T, CommentedConfigurationNode> loadHocon(final @NonNull Path path, final @NonNull ConfigurationOptions options, final @NonNull T instance) {
+  /**
+   * Provides a function to make a general purpose {@link HoconConfigurationLoader}
+   * using the input {@link ConfigurationKey}.
+   */
+  public static final @NonNull Function<ConfigurationKey, ConfigurationLoader<CommentedConfigurationNode>> HOCON_LOADER = key -> {
+    final Path path = key.getPath();
+    if (path == null) return null;
+
     try {
       Files.createDirectories(path.getParent());
 
-      final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
+      return HoconConfigurationLoader.builder()
         .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
         .setSink(() -> Files.newBufferedWriter(path,
           StandardCharsets.UTF_8,
@@ -29,22 +64,50 @@ public final class Configurations {
           StandardOpenOption.WRITE,
           StandardOpenOption.DSYNC)
         )
-        .setDefaultOptions(options)
+        .setDefaultOptions(ConfigurationOptions.defaults())
         .build();
-
-      return Configurations.load(loader, instance);
     } catch (IOException exception) {
       throw new AssertionError("Unable to create configuration directory.", exception);
     }
+  };
+
+  private static final ConcurrentMap<ConfigurationKey, Configuration<?, ?>> CONFIGURATIONS = new ConcurrentHashMap<>();
+
+  /**
+   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader}, {@link Path}
+   * and {@code T} instance.
+   *
+   * @param loaderSupplier The loader supplier
+   * @param key The configuration key
+   * @param instance The instance
+   * @param <T> The instance type
+   * @param <N> The node type
+   * @return The configuration
+   */
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier, final ConfigurationKey key, final @NonNull T instance) {
+    return Configurations.load(loaderSupplier.apply(key), key, instance);
   }
 
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull ConfigurationLoader<N> loader, final @NonNull T instance) {
-    try {
-      final Configuration<T, N> configuration = new Configuration<>(instance, loader);
-      configuration.load();
-      return configuration;
-    } catch (final IOException | ObjectMappingException exception) {
-      throw new AssertionError("Unable to load configuration.", exception);
-    }
+  /**
+   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader}, {@link Path}
+   * and {@code T} instance.
+   *
+   * @param loader The loader supplier
+   * @param key The configuration key
+   * @param instance The instance
+   * @param <T> The instance type
+   * @param <N> The node type
+   * @return The configuration
+   */
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @Nullable ConfigurationLoader<N> loader, final @NonNull ConfigurationKey key, final @NonNull T instance) {
+    return (Configuration<T, N>) Configurations.CONFIGURATIONS.computeIfAbsent(key, ignored -> {
+      try {
+        final Configuration<T, N> configuration = new Configuration<>(key, instance, loader);
+        configuration.load();
+        return configuration;
+      } catch (final IOException | ObjectMappingException exception) {
+        throw new AssertionError("Unable to load configuration.", exception);
+      }
+    });
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
@@ -1,0 +1,50 @@
+package com.mineteria.ignite.api.config;
+
+import ninja.leaping.configurate.ConfigurationNode;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.ConfigurationLoader;
+import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public final class Configurations {
+  public static <T> @NonNull Configuration<T, CommentedConfigurationNode> loadHocon(final @NonNull Path path, final @NonNull ConfigurationOptions options, final @NonNull T instance) {
+    try {
+      Files.createDirectories(path.getParent());
+
+      final HoconConfigurationLoader loader = HoconConfigurationLoader.builder()
+        .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
+        .setSink(() -> Files.newBufferedWriter(path,
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE,
+          StandardOpenOption.DSYNC)
+        )
+        .setDefaultOptions(options)
+        .build();
+
+      return Configurations.load(loader, instance);
+    } catch (IOException exception) {
+      throw new AssertionError("Unable to create configuration directory.", exception);
+    }
+  }
+
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull ConfigurationLoader<N> loader, final @NonNull T instance) {
+    try {
+      final Configuration<T, N> configuration = new Configuration<>(instance, loader);
+      configuration.load();
+      return configuration;
+    } catch (final IOException | ObjectMappingException exception) {
+      throw new AssertionError("Unable to load configuration.", exception);
+    }
+  }
+}

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigPath.java
@@ -1,4 +1,4 @@
-package com.mineteria.ignite.api.config;
+package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;
 
@@ -11,11 +11,11 @@ import java.lang.annotation.Target;
  * Annotation used to specify the mod specific configuration
  * path.
  *
- * <p>Usually the parent is the {@link Configs} path, with
+ * <p>Usually the parent is the {@link ConfigsPath} path, with
  * directory being named after the mod ID.</p>
  */
 @BindingAnnotation
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
-public @interface Config {
+public @interface ConfigPath {
 }

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigPath.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigsPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigsPath.java
@@ -1,4 +1,4 @@
-package com.mineteria.ignite.api.config;
+package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;
 
@@ -16,5 +16,5 @@ import java.lang.annotation.Target;
 @BindingAnnotation
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
-public @interface Configs {
+public @interface ConfigsPath {
 }

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigsPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ConfigsPath.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ModsPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ModsPath.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;

--- a/api/src/main/java/com/mineteria/ignite/api/config/path/ModsPath.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/path/ModsPath.java
@@ -1,4 +1,4 @@
-package com.mineteria.ignite.api.config;
+package com.mineteria.ignite.api.config.path;
 
 import com.google.inject.BindingAnnotation;
 
@@ -16,5 +16,5 @@ import java.lang.annotation.Target;
 @BindingAnnotation
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
-public @interface Mods {
+public @interface ModsPath {
 }

--- a/api/src/main/java/com/mineteria/ignite/api/event/EventHandler.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/EventHandler.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/com/mineteria/ignite/api/event/EventManager.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/EventManager.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/com/mineteria/ignite/api/event/PostPriority.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/PostPriority.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event;
 
 /**

--- a/api/src/main/java/com/mineteria/ignite/api/event/Subscribe.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/Subscribe.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/com/mineteria/ignite/api/event/platform/PlatformConstructEvent.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/platform/PlatformConstructEvent.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event.platform;
 
 import com.mineteria.ignite.api.mod.ModContainer;

--- a/api/src/main/java/com/mineteria/ignite/api/event/platform/PlatformInitializeEvent.java
+++ b/api/src/main/java/com/mineteria/ignite/api/event/platform/PlatformInitializeEvent.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.event.platform;
 
 /**

--- a/api/src/main/java/com/mineteria/ignite/api/mod/ModManager.java
+++ b/api/src/main/java/com/mineteria/ignite/api/mod/ModManager.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.mod;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
+++ b/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
@@ -1,0 +1,153 @@
+package com.mineteria.ignite.api.util;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+// Taken from cpw.mods.modlauncher.api.TypesafeMap
+public final class BlackboardMap {
+  private static final ConcurrentHashMap<Class<?>, BlackboardMap> maps = new ConcurrentHashMap<>();
+
+  private final ConcurrentHashMap<Key<Object>, Object> map = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Key<Object>> keys = new ConcurrentHashMap<>();
+
+  public BlackboardMap() {
+  }
+
+  public BlackboardMap(final @NonNull Class<?> owner) {
+    KeyBuilder.keyBuilders.getOrDefault(owner, Collections.emptyList()).forEach(kb -> kb.buildKey(this));
+    maps.put(owner, this);
+  }
+
+  public <V> @NonNull Optional<V> get(final @NonNull Key<V> key) {
+    return Optional.ofNullable(key.clz.cast(map.get(key)));
+  }
+
+  public <V> @Nullable V computeIfAbsent(final @NonNull Key<V> key, final @NonNull Function<? super Key<V>, ? extends V> valueFunction) {
+    return computeIfAbsent(this.map, key, valueFunction);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <C1, C2, V> V computeIfAbsent(final ConcurrentHashMap<C1, C2> map, final Key<V> key, final Function<? super Key<V>, ? extends V> valueFunction) {
+    return (V) map.computeIfAbsent((C1) key, (Function<? super C1, ? extends C2>) valueFunction);
+  }
+
+  private ConcurrentHashMap<String, Key<Object>> getKeyIdentifiers() {
+    return keys;
+  }
+
+  /**
+   * Unique blackboard key
+   */
+  public static final class Key<T> implements Comparable<Key<T>> {
+    private static final AtomicLong idGenerator = new AtomicLong();
+
+    private final String name;
+    private final long uniqueId;
+    private final Class<T> clz;
+
+    private Key(final String name, final Class<T> clz) {
+      this.clz = clz;
+      this.name = name;
+
+      this.uniqueId = idGenerator.getAndIncrement();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <V> @NonNull Key<V> getOrCreate(final @NonNull BlackboardMap owner, final @NonNull String name, final @NonNull Class<? super V> clazz) {
+      final Key<V> result = (Key<V>) owner.getKeyIdentifiers().computeIfAbsent(name, (n) -> new Key<>(n, (Class<Object>) clazz));
+
+      if (result.clz != clazz) {
+        throw new IllegalArgumentException("Invalid type");
+      }
+
+      return result;
+    }
+
+    public static <V> @NonNull Supplier<Key<V>> getOrCreate(final @NonNull Supplier<BlackboardMap> owner, final @NonNull String name, final @NonNull Class<V> clazz) {
+      return () -> getOrCreate(owner.get(), name, clazz);
+    }
+
+    public final @NonNull String name() {
+      return this.name;
+    }
+
+    @Override
+    public int hashCode() {
+      return (int) (this.uniqueId ^ (this.uniqueId >>> 32));
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object other) {
+      if (other == null) return false;
+
+      try {
+        return this.uniqueId == ((Key<?>) other).uniqueId;
+      } catch (final ClassCastException cc) {
+        return false;
+      }
+    }
+
+    @Override
+    public int compareTo(final @NonNull Key other) {
+      if (this == other) {
+        return 0;
+      }
+
+      if (this.uniqueId < other.uniqueId) {
+        return -1;
+      }
+
+      if (this.uniqueId > other.uniqueId) {
+        return 1;
+      }
+
+      throw new RuntimeException("Huh?");
+    }
+  }
+
+  public static final class KeyBuilder<T> implements Supplier<Key<T>> {
+    private static final Map<Class<?>, List<KeyBuilder<?>>> keyBuilders = new HashMap<>();
+
+    private final Class<?> owner;
+    private final String name;
+    private final Class<? super T> clazz;
+
+    private Key<T> key;
+
+    public KeyBuilder(final @NonNull String name, final @NonNull Class<? super T> clazz, final @NonNull Class<?> owner) {
+      this.name = name;
+      this.clazz = clazz;
+      this.owner = owner;
+
+      keyBuilders.computeIfAbsent(owner, k -> new ArrayList<>()).add(this);
+    }
+
+    final void buildKey(final BlackboardMap map) {
+      this.key = Key.getOrCreate(map, name, clazz);
+    }
+
+    @Override
+    public @NonNull Key<T> get() {
+      if (this.key == null && maps.containsKey(this.owner)) {
+        buildKey(maps.get(this.owner));
+      }
+
+      if (this.key == null) {
+        throw new NullPointerException("Missing map");
+      }
+
+      return this.key;
+    }
+  }
+}

--- a/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
+++ b/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
@@ -27,38 +27,24 @@ package com.mineteria.ignite.api.util;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
-// Taken from cpw.mods.modlauncher.api.TypesafeMap
 public final class BlackboardMap {
-  private static final ConcurrentHashMap<Class<?>, BlackboardMap> maps = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Key<Object>, Object> blackboardMap = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Key<Object>> blackboardKeys = new ConcurrentHashMap<>();
 
-  private final ConcurrentHashMap<Key<Object>, Object> map = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Key<Object>> keys = new ConcurrentHashMap<>();
-
-  public BlackboardMap() {
-  }
-
-  public BlackboardMap(final @NonNull Class<?> owner) {
-    KeyBuilder.keyBuilders.getOrDefault(owner, Collections.emptyList()).forEach(kb -> kb.buildKey(this));
-    maps.put(owner, this);
-  }
+  public BlackboardMap() {}
 
   public <V> @NonNull Optional<V> get(final @NonNull Key<V> key) {
-    return Optional.ofNullable(key.clz.cast(map.get(key)));
+    return Optional.ofNullable(key.type.cast(this.blackboardMap.get(key)));
   }
 
   public <V> @Nullable V computeIfAbsent(final @NonNull Key<V> key, final @NonNull Function<? super Key<V>, ? extends V> valueFunction) {
-    return computeIfAbsent(this.map, key, valueFunction);
+    return computeIfAbsent(this.blackboardMap, key, valueFunction);
   }
 
   @SuppressWarnings("unchecked")
@@ -66,112 +52,61 @@ public final class BlackboardMap {
     return (V) map.computeIfAbsent((C1) key, (Function<? super C1, ? extends C2>) valueFunction);
   }
 
-  private ConcurrentHashMap<String, Key<Object>> getKeyIdentifiers() {
-    return keys;
+  private ConcurrentHashMap<String, Key<Object>> getKeys() {
+    return this.blackboardKeys;
   }
 
   /**
    * Unique blackboard key
    */
   public static final class Key<T> implements Comparable<Key<T>> {
-    private static final AtomicLong idGenerator = new AtomicLong();
-
-    private final String name;
-    private final long uniqueId;
-    private final Class<T> clz;
-
-    private Key(final String name, final Class<T> clz) {
-      this.clz = clz;
-      this.name = name;
-
-      this.uniqueId = idGenerator.getAndIncrement();
-    }
-
     @SuppressWarnings("unchecked")
     public static <V> @NonNull Key<V> getOrCreate(final @NonNull BlackboardMap owner, final @NonNull String name, final @NonNull Class<? super V> clazz) {
-      final Key<V> result = (Key<V>) owner.getKeyIdentifiers().computeIfAbsent(name, (n) -> new Key<>(n, (Class<Object>) clazz));
+      final Key<V> result = (Key<V>) owner.getKeys().computeIfAbsent(name, (n) -> new Key<>(n, (Class<Object>) clazz));
 
-      if (result.clz != clazz) {
-        throw new IllegalArgumentException("Invalid type");
+      if (result.type != clazz) {
+        throw new IllegalArgumentException("Invalid type!");
       }
 
       return result;
     }
 
-    public static <V> @NonNull Supplier<Key<V>> getOrCreate(final @NonNull Supplier<BlackboardMap> owner, final @NonNull String name, final @NonNull Class<V> clazz) {
-      return () -> getOrCreate(owner.get(), name, clazz);
+    private static final AtomicLong ID_GENERATOR = new AtomicLong();
+
+    private final String name;
+    private final long identifier;
+    private final Class<T> type;
+
+    private Key(final String name, final Class<T> type) {
+      this.type = type;
+      this.name = name;
+
+      this.identifier = Key.ID_GENERATOR.getAndIncrement();
     }
 
-    public final @NonNull String name() {
+    public final @NonNull String getName() {
       return this.name;
     }
 
     @Override
     public int hashCode() {
-      return (int) (this.uniqueId ^ (this.uniqueId >>> 32));
+      return (int) (this.identifier ^ (this.identifier >>> 32));
     }
 
     @Override
     public boolean equals(final @Nullable Object other) {
       if (other == null) return false;
-
-      try {
-        return this.uniqueId == ((Key<?>) other).uniqueId;
-      } catch (final ClassCastException cc) {
-        return false;
-      }
+      if (!(other instanceof Key)) return false;
+      final Key<?> that = (Key<?>) other;
+      return Objects.equals(this.identifier, that.identifier);
     }
 
     @Override
     public int compareTo(final @NonNull Key other) {
-      if (this == other) {
-        return 0;
-      }
-
-      if (this.uniqueId < other.uniqueId) {
-        return -1;
-      }
-
-      if (this.uniqueId > other.uniqueId) {
-        return 1;
-      }
-
+      if (this == other) return 0;
+      if (this.identifier < other.identifier) return -1;
+      if (this.identifier > other.identifier) return 1;
       throw new RuntimeException("Huh?");
-    }
-  }
-
-  public static final class KeyBuilder<T> implements Supplier<Key<T>> {
-    private static final Map<Class<?>, List<KeyBuilder<?>>> keyBuilders = new HashMap<>();
-
-    private final Class<?> owner;
-    private final String name;
-    private final Class<? super T> clazz;
-
-    private Key<T> key;
-
-    public KeyBuilder(final @NonNull String name, final @NonNull Class<? super T> clazz, final @NonNull Class<?> owner) {
-      this.name = name;
-      this.clazz = clazz;
-      this.owner = owner;
-
-      keyBuilders.computeIfAbsent(owner, k -> new ArrayList<>()).add(this);
-    }
-
-    final void buildKey(final BlackboardMap map) {
-      this.key = Key.getOrCreate(map, name, clazz);
-    }
-
-    @Override
-    public @NonNull Key<T> get() {
-      if (this.key == null && maps.containsKey(this.owner)) {
-        buildKey(maps.get(this.owner));
-      }
-
-      if (this.key == null) {
-        throw new NullPointerException("Missing map");
-      }
-
-      return this.key;
     }
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
+++ b/api/src/main/java/com/mineteria/ignite/api/util/BlackboardMap.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.api.util;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 subprojects {
   apply plugin: "java-library"
+  apply plugin: "net.minecrell.licenser"
 
   group = "com.mineteria.ignite"
   version = "0.2.1-SNAPSHOT"
@@ -29,7 +30,7 @@ subprojects {
   }
 
   license {
-    header = file("header.txt")
+    header = file("../header.txt")
     newLine = false
     ext {
       name = "Ignite"

--- a/example/src/main/java/com/mineteria/example/ExampleConfig.java
+++ b/example/src/main/java/com/mineteria/example/ExampleConfig.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.example;
 
 import ninja.leaping.configurate.objectmapping.Setting;

--- a/example/src/main/java/com/mineteria/example/ExampleConfig.java
+++ b/example/src/main/java/com/mineteria/example/ExampleConfig.java
@@ -1,0 +1,10 @@
+package com.mineteria.example;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+@ConfigSerializable
+public final class ExampleConfig {
+  @Setting(value = "test", comment = "Test configuration property.")
+  public boolean test = true;
+}

--- a/example/src/main/java/com/mineteria/example/ExampleMod.java
+++ b/example/src/main/java/com/mineteria/example/ExampleMod.java
@@ -2,29 +2,31 @@ package com.mineteria.example;
 
 import com.google.inject.Inject;
 import com.mineteria.ignite.api.Platform;
-import com.mineteria.ignite.api.config.Config;
+import com.mineteria.ignite.api.config.path.ConfigPath;
 import com.mineteria.ignite.api.event.Subscribe;
 import com.mineteria.ignite.api.event.platform.PlatformInitializeEvent;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.nio.file.Path;
 
+@SuppressWarnings("UnstableApiUsage")
 public final class ExampleMod {
   private final Logger logger;
   private final Platform platform;
-  private final Path configuration;
+  private final Path configurationPath;
 
   @Inject
   public ExampleMod(final Logger logger,
                     final Platform platform,
-                    final @Config Path configuration) {
+                    final @ConfigPath Path configurationPath) {
     this.logger = logger;
     this.platform = platform;
-    this.configuration = configuration;
+    this.configurationPath = configurationPath;
   }
 
   @Subscribe
-  public void onInitialize(final PlatformInitializeEvent event) {
+  public void onInitialize(final @NonNull PlatformInitializeEvent event) {
     this.logger.info("Hello Initialization!");
   }
 }

--- a/example/src/main/java/com/mineteria/example/ExampleMod.java
+++ b/example/src/main/java/com/mineteria/example/ExampleMod.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.example;
 
 import com.google.inject.Inject;

--- a/example/src/main/java/com/mineteria/example/mixin/core/MixinCraftServer.java
+++ b/example/src/main/java/com/mineteria/example/mixin/core/MixinCraftServer.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.example.mixin.core;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
+++ b/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
@@ -1,10 +1,34 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.example.mixin.plugins;
 
 import com.mineteria.example.ExampleConfig;
 import com.mineteria.ignite.api.IgniteBlackboard;
 import com.mineteria.ignite.api.config.Configuration;
+import com.mineteria.ignite.api.config.ConfigurationKey;
 import com.mineteria.ignite.api.config.Configurations;
-import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -16,6 +40,11 @@ import java.util.List;
 import java.util.Set;
 
 public final class CorePlugin implements IMixinConfigPlugin {
+  private static final ConfigurationKey EXAMPLE_KEY = ConfigurationKey.key("example", IgniteBlackboard.getProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH)
+    .resolve("example")
+    .resolve("example.conf")
+  );
+
   @Override
   public void onLoad(final @NonNull String mixinPackage) {
   }
@@ -27,11 +56,7 @@ public final class CorePlugin implements IMixinConfigPlugin {
 
   @Override
   public final boolean shouldApplyMixin(final @NonNull String targetClassName, final @NonNull String mixinClassName) {
-    final Configuration<ExampleConfig, CommentedConfigurationNode> config = Configurations.loadHocon(
-      IgniteBlackboard.getProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH).resolve("dream").resolve("dream.conf"),
-      ConfigurationOptions.defaults(),
-      new ExampleConfig()
-    );
+    final Configuration<ExampleConfig, CommentedConfigurationNode> config = Configurations.load(Configurations.HOCON_LOADER, CorePlugin.EXAMPLE_KEY, new ExampleConfig());
 
     return config.getInstance().test;
   }

--- a/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
+++ b/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
@@ -1,5 +1,11 @@
 package com.mineteria.example.mixin.plugins;
 
+import com.mineteria.example.ExampleConfig;
+import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.config.Configuration;
+import com.mineteria.ignite.api.config.Configurations;
+import ninja.leaping.configurate.ConfigurationOptions;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.objectweb.asm.tree.ClassNode;
@@ -21,7 +27,13 @@ public final class CorePlugin implements IMixinConfigPlugin {
 
   @Override
   public final boolean shouldApplyMixin(final @NonNull String targetClassName, final @NonNull String mixinClassName) {
-    return true;
+    final Configuration<ExampleConfig, CommentedConfigurationNode> config = Configurations.loadHocon(
+      IgniteBlackboard.getProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH).resolve("dream").resolve("dream.conf"),
+      ConfigurationOptions.defaults(),
+      new ExampleConfig()
+    );
+
+    return config.getInstance().test;
   }
 
   @Override

--- a/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
+++ b/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
@@ -25,7 +25,7 @@
 package com.mineteria.example.mixin.plugins;
 
 import com.mineteria.example.ExampleConfig;
-import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.Blackboard;
 import com.mineteria.ignite.api.config.Configuration;
 import com.mineteria.ignite.api.config.ConfigurationKey;
 import com.mineteria.ignite.api.config.Configurations;
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Set;
 
 public final class CorePlugin implements IMixinConfigPlugin {
-  private static final ConfigurationKey EXAMPLE_KEY = ConfigurationKey.key("example", IgniteBlackboard.getProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH)
+  private static final ConfigurationKey EXAMPLE_KEY = ConfigurationKey.key("example", Blackboard.getProperty(Blackboard.CONFIG_DIRECTORY_PATH)
     .resolve("example")
     .resolve("example.conf")
   );

--- a/example/src/main/java/com/mineteria/example/package-info.java
+++ b/example/src/main/java/com/mineteria/example/package-info.java
@@ -1,1 +1,25 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.example;

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -57,6 +57,7 @@ shadowJar {
     // API
     include(project(":api"))
 
+    // Logging
     include dependency("org.apache.logging.log4j:log4j-api")
     include dependency("org.apache.logging.log4j:log4j-core")
     include dependency("org.checkerframework:checker-qual")
@@ -71,6 +72,9 @@ shadowJar {
     include dependency("org.spongepowered:configurate-hocon")
     include dependency("org.spongepowered:configurate-yaml")
     include dependency("org.spongepowered:configurate-gson")
+    include dependency("com.typesafe:config")
+    include dependency("com.google.code.gson:gson")
+    include dependency("org.yaml:snakeyaml")
 
     // Event
     include dependency("net.kyori:event-api")
@@ -105,7 +109,7 @@ shadowJar {
     include dependency("net.sf.jopt-simple:jopt-simple")
   }
 
-  relocate "com.google.common", "com.mineteria.ignite.relocate.google"
+//  relocate "com.google.common", "com.mineteria.ignite.relocate.google"
 }
 
 task copyFinalJarToTarget(type: DefaultTask) {

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -1,8 +1,9 @@
 apply plugin: "java-library"
 apply plugin: "com.github.johnrengelman.shadow"
 
-import java.nio.file.Path
+
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 archivesBaseName = "ignite-launcher"
@@ -108,8 +109,6 @@ shadowJar {
     include dependency("cpw.mods:grossjava9hacks")
     include dependency("net.sf.jopt-simple:jopt-simple")
   }
-
-//  relocate "com.google.common", "com.mineteria.ignite.relocate.google"
 }
 
 task copyFinalJarToTarget(type: DefaultTask) {

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/IgniteBootstrap.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/IgniteBootstrap.java
@@ -24,7 +24,7 @@
  */
 package com.mineteria.ignite.applaunch;
 
-import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.Blackboard;
 import com.mineteria.ignite.applaunch.agent.Agent;
 import com.mineteria.ignite.applaunch.mod.ModEngine;
 import cpw.mods.modlauncher.Launcher;
@@ -45,22 +45,22 @@ public final class IgniteBootstrap {
   /**
    * The launch jar path.
    */
-  public static final @NonNull Path LAUNCH_JAR = Paths.get(System.getProperty(IgniteBlackboard.LAUNCH_JAR.name(), "./server.jar"));
+  public static final @NonNull Path LAUNCH_JAR = Paths.get(System.getProperty(Blackboard.LAUNCH_JAR.getName(), "./server.jar"));
 
   /**
    * The launch target class path.
    */
-  public static final @NonNull String LAUNCH_TARGET = System.getProperty(IgniteBlackboard.LAUNCH_TARGET.name(), "org.bukkit.craftbukkit.Main");
+  public static final @NonNull String LAUNCH_TARGET = System.getProperty(Blackboard.LAUNCH_TARGET.getName(), "org.bukkit.craftbukkit.Main");
 
   /**
    * The mods directory.
    */
-  public static final @NonNull Path MOD_TARGET_PATH = Paths.get(System.getProperty(IgniteBlackboard.MOD_DIRECTORY_PATH.name(), "./mods"));
+  public static final @NonNull Path MOD_TARGET_PATH = Paths.get(System.getProperty(Blackboard.MOD_DIRECTORY_PATH.getName(), "./mods"));
 
   /**
    * The configs directory.
    */
-  public static final @NonNull Path CONFIG_TARGET_PATH = Paths.get(System.getProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH.name(), "./configs"));
+  public static final @NonNull Path CONFIG_TARGET_PATH = Paths.get(System.getProperty(Blackboard.CONFIG_DIRECTORY_PATH.getName(), "./configs"));
 
   private static IgniteBootstrap instance;
 
@@ -109,11 +109,11 @@ public final class IgniteBootstrap {
     logger.info("Ignite Launcher version {}", IgniteBootstrap.class.getPackage().getImplementationVersion());
 
     // Blackboard
-    IgniteBlackboard.setProperty(IgniteBlackboard.LAUNCH_ARGUMENTS, Collections.unmodifiableList(arguments));
-    IgniteBlackboard.setProperty(IgniteBlackboard.LAUNCH_JAR, IgniteBootstrap.LAUNCH_JAR);
-    IgniteBlackboard.setProperty(IgniteBlackboard.LAUNCH_TARGET, IgniteBootstrap.LAUNCH_TARGET);
-    IgniteBlackboard.setProperty(IgniteBlackboard.MOD_DIRECTORY_PATH, IgniteBootstrap.MOD_TARGET_PATH);
-    IgniteBlackboard.setProperty(IgniteBlackboard.CONFIG_DIRECTORY_PATH, IgniteBootstrap.CONFIG_TARGET_PATH);
+    Blackboard.setProperty(Blackboard.LAUNCH_ARGUMENTS, Collections.unmodifiableList(arguments));
+    Blackboard.setProperty(Blackboard.LAUNCH_JAR, IgniteBootstrap.LAUNCH_JAR);
+    Blackboard.setProperty(Blackboard.LAUNCH_TARGET, IgniteBootstrap.LAUNCH_TARGET);
+    Blackboard.setProperty(Blackboard.MOD_DIRECTORY_PATH, IgniteBootstrap.MOD_TARGET_PATH);
+    Blackboard.setProperty(Blackboard.CONFIG_DIRECTORY_PATH, IgniteBootstrap.CONFIG_TARGET_PATH);
 
     // Modlauncher
     logger.info("Preparing ModLauncher with arguments {}", launchArguments);

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/IgniteBootstrap.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/IgniteBootstrap.java
@@ -24,6 +24,7 @@
  */
 package com.mineteria.ignite.applaunch;
 
+import com.mineteria.ignite.api.IgniteBlackboard;
 import com.mineteria.ignite.applaunch.agent.Agent;
 import com.mineteria.ignite.applaunch.mod.ModEngine;
 import cpw.mods.modlauncher.Launcher;

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
@@ -24,7 +24,7 @@
  */
 package com.mineteria.ignite.applaunch.handler;
 
-import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.Blackboard;
 import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.applaunch.IgniteBootstrap;
 import com.mineteria.ignite.applaunch.mod.ModEngine;
@@ -232,7 +232,7 @@ public final class IgniteLaunchService implements ILaunchHandlerService {
    * @param launchClassLoader The transforming class loader to load classes with
    */
   protected void launchService0(final @NonNull String[] arguments, final @NonNull ITransformingClassLoader launchClassLoader) throws Exception {
-    final Path launchJar = IgniteBlackboard.getProperty(IgniteBlackboard.LAUNCH_JAR);
+    final Path launchJar = Blackboard.getProperty(Blackboard.LAUNCH_JAR);
     if (launchJar == null || !Files.exists(launchJar)) {
       throw new IllegalStateException("No launch jar was found!");
     } else {

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
@@ -25,7 +25,7 @@
 package com.mineteria.ignite.applaunch.handler;
 
 import com.mineteria.ignite.api.mod.ModResource;
-import com.mineteria.ignite.applaunch.IgniteBlackboard;
+import com.mineteria.ignite.api.IgniteBlackboard;
 import com.mineteria.ignite.applaunch.IgniteBootstrap;
 import com.mineteria.ignite.applaunch.mod.ModEngine;
 import cpw.mods.gross.Java9ClassLoaderUtil;
@@ -73,26 +73,38 @@ public final class IgniteLaunchService implements ILaunchHandlerService {
     "com.mineteria.ignite.applaunch.",
     "com.mineteria.ignite.relocate.",
 
-    // Libraries
-    "org.spongepowered.asm.",
-    "ninja.leaping.configurate.",
-    "javax.inject.",
-    "joptsimple.",
-    "gnu.trove.",
-    "it.unimi.dsi.fastutil.",
-    "org.apache.logging.log4j.",
-    "org.yaml.snakeyaml.",
-    "com.google.inject.",
-    "com.google.common.",
-    "com.google.gson.",
-    "javax.annotation.",
-    "org.apache.commons.",
-
     // Logging
+    "org.apache.logging.log4j.",
+    "org.checkerframework.",
     "net.minecrell.terminalconsole.",
+    "org.jline.",
     "com.sun.jna.",
-    "org.fusesource.jansi.",
-    "org.jline."
+
+    // Configuration
+    "ninja.leaping.configurate.",
+    "com.typesafe.config.",
+    "com.google.gson.",
+    "org.yaml.snakeyaml.",
+
+    // Common
+    "com.google.common.",
+    "com.google.inject.",
+    "javax.annotation.",
+    "javax.inject.",
+    "org.aopalliance.",
+
+    // ASM
+    "org.objectweb.asm.",
+
+    // Mixin
+    "org.spongepowered.asm.",
+
+    // Access Transformers
+    "net.minecraftforge.accesstransformer.",
+    "org.antlr.v4.runtime.",
+
+    // Core
+    "joptsimple."
   );
 
   private final Logger logger = LogManager.getLogger("IgniteLaunch");

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/handler/IgniteLaunchService.java
@@ -24,8 +24,8 @@
  */
 package com.mineteria.ignite.applaunch.handler;
 
-import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.applaunch.IgniteBootstrap;
 import com.mineteria.ignite.applaunch.mod.ModEngine;
 import cpw.mods.gross.Java9ClassLoaderUtil;

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLoader.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLoader.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.applaunch.mod;
 
 import com.google.gson.Gson;

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
@@ -24,8 +24,8 @@
  */
 package com.mineteria.ignite.applaunch.mod;
 
-import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.applaunch.util.IgniteConstants;
 import org.checkerframework.checker.nullness.qual.NonNull;
 

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
@@ -25,7 +25,7 @@
 package com.mineteria.ignite.applaunch.mod;
 
 import com.mineteria.ignite.api.mod.ModResource;
-import com.mineteria.ignite.applaunch.IgniteBlackboard;
+import com.mineteria.ignite.api.IgniteBlackboard;
 import com.mineteria.ignite.applaunch.util.IgniteConstants;
 import org.checkerframework.checker.nullness.qual.NonNull;
 

--- a/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
+++ b/launcher/src/main/java/com/mineteria/ignite/applaunch/mod/ModResourceLocator.java
@@ -24,7 +24,7 @@
  */
 package com.mineteria.ignite.applaunch.mod;
 
-import com.mineteria.ignite.api.IgniteBlackboard;
+import com.mineteria.ignite.api.Blackboard;
 import com.mineteria.ignite.api.mod.ModResource;
 import com.mineteria.ignite.applaunch.util.IgniteConstants;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -45,7 +45,7 @@ public final class ModResourceLocator {
   public final @NonNull List<ModResource> locateResources(final @NonNull ModEngine engine) {
     final List<ModResource> modResources = new ArrayList<>();
 
-    final Path modDirectory = IgniteBlackboard.getProperty(IgniteBlackboard.MOD_DIRECTORY_PATH);
+    final Path modDirectory = Blackboard.getProperty(Blackboard.MOD_DIRECTORY_PATH);
     if (modDirectory == null || Files.notExists(modDirectory)) {
       engine.getLogger().warn("Mod directory '{}' does not exist for mod resource locator. Skipping...", modDirectory);
       return modResources;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/IgniteLaunch.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/IgniteLaunch.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch;
 
 import com.google.inject.Guice;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/IgnitePlatform.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/IgnitePlatform.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch;
 
 import com.google.inject.Inject;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/IgnitePlatform.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/IgnitePlatform.java
@@ -2,8 +2,8 @@ package com.mineteria.ignite.launch;
 
 import com.google.inject.Inject;
 import com.mineteria.ignite.api.Platform;
-import com.mineteria.ignite.api.config.Configs;
-import com.mineteria.ignite.api.config.Mods;
+import com.mineteria.ignite.api.config.path.ConfigsPath;
+import com.mineteria.ignite.api.config.path.ModsPath;
 import com.mineteria.ignite.api.event.EventManager;
 import com.mineteria.ignite.api.mod.ModManager;
 import com.mineteria.ignite.launch.event.IgniteEventManager;
@@ -23,8 +23,8 @@ public final class IgnitePlatform implements Platform {
   private final Path mods;
 
   @Inject
-  public IgnitePlatform(final @NonNull @Configs Path configs,
-                        final @NonNull @Mods Path mods) {
+  public IgnitePlatform(final @NonNull @ConfigsPath Path configs,
+                        final @NonNull @ModsPath Path mods) {
     this.mods = mods;
     this.configs = configs;
 

--- a/launcher/src/main/java/com/mineteria/ignite/launch/event/IgniteEventManager.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/event/IgniteEventManager.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.event;
 
 import static java.util.Objects.requireNonNull;
@@ -38,8 +62,8 @@ public final class IgniteEventManager implements EventManager {
 
   public IgniteEventManager(final @NonNull IgnitePlatform platform) {
     // Add event executors to the mod class loader.
-//    final ModClassLoader classLoader = AccessController.doPrivileged((PrivilegedAction<ModClassLoader>) () -> new ModClassLoader(new URL[0]));
-//    classLoader.addLoaders();
+    final ModClassLoader classLoader = AccessController.doPrivileged((PrivilegedAction<ModClassLoader>) () -> new ModClassLoader(new URL[0]));
+    classLoader.addLoaders();
 
     this.platform = platform;
 
@@ -52,7 +76,7 @@ public final class IgniteEventManager implements EventManager {
 
     this.methodAdapter = new SimpleMethodSubscriptionAdapter<>(
       bus,
-      new ASMEventExecutorFactory<>(/*classLoader*/),
+      new ASMEventExecutorFactory<>(classLoader),
       new IgniteMethodScanner()
     );
   }

--- a/launcher/src/main/java/com/mineteria/ignite/launch/event/IgniteEventManager.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/event/IgniteEventManager.java
@@ -38,8 +38,8 @@ public final class IgniteEventManager implements EventManager {
 
   public IgniteEventManager(final @NonNull IgnitePlatform platform) {
     // Add event executors to the mod class loader.
-    final ModClassLoader classLoader = AccessController.doPrivileged((PrivilegedAction<ModClassLoader>) () -> new ModClassLoader(new URL[0]));
-    classLoader.addLoaders();
+//    final ModClassLoader classLoader = AccessController.doPrivileged((PrivilegedAction<ModClassLoader>) () -> new ModClassLoader(new URL[0]));
+//    classLoader.addLoaders();
 
     this.platform = platform;
 
@@ -52,7 +52,7 @@ public final class IgniteEventManager implements EventManager {
 
     this.methodAdapter = new SimpleMethodSubscriptionAdapter<>(
       bus,
-      new ASMEventExecutorFactory<>(classLoader),
+      new ASMEventExecutorFactory<>(/*classLoader*/),
       new IgniteMethodScanner()
     );
   }

--- a/launcher/src/main/java/com/mineteria/ignite/launch/inject/IgniteModule.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/inject/IgniteModule.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.inject;
 
 import com.google.inject.AbstractModule;
@@ -5,6 +29,8 @@ import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.mineteria.ignite.api.Ignite;
 import com.mineteria.ignite.api.Platform;
+import com.mineteria.ignite.api.config.path.ConfigsPath;
+import com.mineteria.ignite.api.config.path.ModsPath;
 import com.mineteria.ignite.applaunch.IgniteBootstrap;
 import com.mineteria.ignite.launch.IgnitePlatform;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -19,24 +45,24 @@ public final class IgniteModule extends AbstractModule {
     this.bind(Platform.class).to(IgnitePlatform.class).in(Scopes.SINGLETON);
 
     this.bind(Path.class)
-      .annotatedWith(com.mineteria.ignite.api.config.path.ModsPath.class)
-      .toProvider(ModsPath.class)
+      .annotatedWith(ModsPath.class)
+      .toProvider(ModsPathProvider.class)
       .in(Scopes.SINGLETON);
 
     this.bind(Path.class)
-      .annotatedWith(com.mineteria.ignite.api.config.path.ConfigsPath.class)
-      .toProvider(ConfigsPath.class)
+      .annotatedWith(ConfigsPath.class)
+      .toProvider(ConfigsPathProvider.class)
       .in(Scopes.SINGLETON);
   }
 
-  /* package */ static final class ModsPath implements Provider<Path> {
+  /* package */ static final class ModsPathProvider implements Provider<Path> {
     @Override
     public final @NonNull Path get() {
       return IgniteBootstrap.MOD_TARGET_PATH;
     }
   }
 
-  /* package */ static final class ConfigsPath implements Provider<Path> {
+  /* package */ static final class ConfigsPathProvider implements Provider<Path> {
     @Override
     public final @NonNull Path get() {
       return IgniteBootstrap.CONFIG_TARGET_PATH;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/inject/IgniteModule.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/inject/IgniteModule.java
@@ -5,8 +5,6 @@ import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.mineteria.ignite.api.Ignite;
 import com.mineteria.ignite.api.Platform;
-import com.mineteria.ignite.api.config.Configs;
-import com.mineteria.ignite.api.config.Mods;
 import com.mineteria.ignite.applaunch.IgniteBootstrap;
 import com.mineteria.ignite.launch.IgnitePlatform;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -21,12 +19,12 @@ public final class IgniteModule extends AbstractModule {
     this.bind(Platform.class).to(IgnitePlatform.class).in(Scopes.SINGLETON);
 
     this.bind(Path.class)
-      .annotatedWith(Mods.class)
+      .annotatedWith(com.mineteria.ignite.api.config.path.ModsPath.class)
       .toProvider(ModsPath.class)
       .in(Scopes.SINGLETON);
 
     this.bind(Path.class)
-      .annotatedWith(Configs.class)
+      .annotatedWith(com.mineteria.ignite.api.config.path.ConfigsPath.class)
       .toProvider(ConfigsPath.class)
       .in(Scopes.SINGLETON);
   }

--- a/launcher/src/main/java/com/mineteria/ignite/launch/inject/ModModule.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/inject/ModModule.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.inject;
 
 import com.google.inject.AbstractModule;
@@ -30,16 +54,16 @@ public final class ModModule extends AbstractModule {
 
     this.bind(Path.class)
       .annotatedWith(ConfigPath.class)
-      .toProvider(ModConfigPath.class)
+      .toProvider(ConfigPathProvider.class)
       .in(Scopes.SINGLETON);
   }
 
-  /* package */ static final class ModConfigPath implements Provider<Path> {
+  /* package */ static final class ConfigPathProvider implements Provider<Path> {
     private final Path configs;
     private final ModContainer container;
 
     @Inject
-    public ModConfigPath(final @NonNull @ConfigsPath Path configs, final @NonNull ModContainer container) {
+    public ConfigPathProvider(final @NonNull @ConfigsPath Path configs, final @NonNull ModContainer container) {
       this.configs = configs;
       this.container = container;
     }

--- a/launcher/src/main/java/com/mineteria/ignite/launch/inject/ModModule.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/inject/ModModule.java
@@ -4,8 +4,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Scopes;
-import com.mineteria.ignite.api.config.Config;
-import com.mineteria.ignite.api.config.Configs;
+import com.mineteria.ignite.api.config.path.ConfigPath;
+import com.mineteria.ignite.api.config.path.ConfigsPath;
 import com.mineteria.ignite.api.mod.ModContainer;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -29,7 +29,7 @@ public final class ModModule extends AbstractModule {
     this.bind(Logger.class).toInstance(this.container.getLogger());
 
     this.bind(Path.class)
-      .annotatedWith(Config.class)
+      .annotatedWith(ConfigPath.class)
       .toProvider(ModConfigPath.class)
       .in(Scopes.SINGLETON);
   }
@@ -39,7 +39,7 @@ public final class ModModule extends AbstractModule {
     private final ModContainer container;
 
     @Inject
-    public ModConfigPath(final @NonNull @Configs Path configs, final @NonNull ModContainer container) {
+    public ModConfigPath(final @NonNull @ConfigsPath Path configs, final @NonNull ModContainer container) {
       this.configs = configs;
       this.container = container;
     }

--- a/launcher/src/main/java/com/mineteria/ignite/launch/mod/IgniteModManager.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/mod/IgniteModManager.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.mod;
 
 import static java.util.Objects.requireNonNull;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModClassLoader.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModClassLoader.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.mod;
 
 import com.mineteria.ignite.launch.IgniteLaunch;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModDependencyResolver.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModDependencyResolver.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.mod;
 
 import com.google.common.collect.Maps;

--- a/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModLoader.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModLoader.java
@@ -2,6 +2,7 @@ package com.mineteria.ignite.launch.mod;
 
 import com.google.inject.Injector;
 import com.mineteria.ignite.api.mod.ModContainer;
+import com.mineteria.ignite.applaunch.agent.Agent;
 import com.mineteria.ignite.launch.IgniteLaunch;
 import com.mineteria.ignite.launch.IgnitePlatform;
 import com.mineteria.ignite.launch.inject.ModModule;
@@ -57,14 +58,16 @@ public final class ModLoader {
   private Object instantiateContainer(final ModContainer container) throws IllegalStateException {
     try {
       // Add the resource to the class loader.
-      final URL modJar = container.getResource().getPath().toUri().toURL();
-      final ModClassLoader classLoader = new ModClassLoader(new URL[] { modJar });
-      classLoader.addLoaders();
+      Agent.addJar(container.getResource().getPath());
+//      final URL modJar = container.getResource().getPath().toUri().toURL();
+//      final ModClassLoader classLoader = new ModClassLoader(new URL[] { modJar });
+//      classLoader.addLoaders();
 
       final String targetClass = container.getConfig().getTarget();
       if (targetClass != null) {
         // Load the class.
-        final Class<?> modClass = classLoader.loadClass(targetClass);
+//        final Class<?> modClass = classLoader.loadClass(targetClass);
+        final Class<?> modClass = Class.forName(targetClass, true, IgniteLaunch.class.getClassLoader());
 
         final Injector parentInjector = IgniteLaunch.getInstance().getInjector();
         if (parentInjector != null) {

--- a/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModLoader.java
+++ b/launcher/src/main/java/com/mineteria/ignite/launch/mod/ModLoader.java
@@ -1,8 +1,31 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Mineteria <https://mineteria.com/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.mineteria.ignite.launch.mod;
 
 import com.google.inject.Injector;
 import com.mineteria.ignite.api.mod.ModContainer;
-import com.mineteria.ignite.applaunch.agent.Agent;
 import com.mineteria.ignite.launch.IgniteLaunch;
 import com.mineteria.ignite.launch.IgnitePlatform;
 import com.mineteria.ignite.launch.inject.ModModule;
@@ -58,16 +81,14 @@ public final class ModLoader {
   private Object instantiateContainer(final ModContainer container) throws IllegalStateException {
     try {
       // Add the resource to the class loader.
-      Agent.addJar(container.getResource().getPath());
-//      final URL modJar = container.getResource().getPath().toUri().toURL();
-//      final ModClassLoader classLoader = new ModClassLoader(new URL[] { modJar });
-//      classLoader.addLoaders();
+      final URL modJar = container.getResource().getPath().toUri().toURL();
+      final ModClassLoader classLoader = new ModClassLoader(new URL[] { modJar });
+      classLoader.addLoaders();
 
       final String targetClass = container.getConfig().getTarget();
       if (targetClass != null) {
         // Load the class.
-//        final Class<?> modClass = classLoader.loadClass(targetClass);
-        final Class<?> modClass = Class.forName(targetClass, true, IgniteLaunch.class.getClassLoader());
+        final Class<?> modClass = classLoader.loadClass(targetClass);
 
         final Injector parentInjector = IgniteLaunch.getInstance().getInjector();
         if (parentInjector != null) {


### PR DESCRIPTION
Fixes the configurations for mixin plugins not being available at the time it is needed (at the beginning of the launch transition). Which is before the mod is initialized. This provides a utility to allow mixin plugins to load configuration files they will need, cached so that when the mod is initialized, they can use the same instance of the configuration file themselves.