### PR TITLE
Configuration Object Mapping Fix

### DIFF
--- a/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
@@ -27,15 +27,19 @@ package com.mineteria.ignite.api.config;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.ConfigurationOptions;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import ninja.leaping.configurate.gson.GsonConfigurationLoader;
 import ninja.leaping.configurate.hocon.HoconConfigurationLoader;
+import ninja.leaping.configurate.loader.AbstractConfigurationLoader;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
 import ninja.leaping.configurate.objectmapping.ObjectMappingException;
+import ninja.leaping.configurate.yaml.YAMLConfigurationLoader;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,69 +49,115 @@ import java.util.function.Function;
 @SuppressWarnings("unchecked")
 public final class Configurations {
   /**
+   * Provides a function to make a general purpose {@link GsonConfigurationLoader}
+   * using the input {@link ConfigurationKey}.
+   */
+  public static final @NonNull Function<ConfigurationKey, ConfigurationLoader<ConfigurationNode>> GSON_LOADER = key -> Configurations.createLoader(key, path -> GsonConfigurationLoader.builder()
+    .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
+    .setSink(() -> Files.newBufferedWriter(path, StandardCharsets.UTF_8, Configurations.SINK_OPTIONS))
+    .setDefaultOptions(ConfigurationOptions.defaults())
+    .build()
+  );
+
+  /**
    * Provides a function to make a general purpose {@link HoconConfigurationLoader}
    * using the input {@link ConfigurationKey}.
    */
-  public static final @NonNull Function<ConfigurationKey, ConfigurationLoader<CommentedConfigurationNode>> HOCON_LOADER = key -> {
-    final Path path = key.getPath();
-    if (path == null) return null;
-
-    try {
-      Files.createDirectories(path.getParent());
-
-      return HoconConfigurationLoader.builder()
-        .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
-        .setSink(() -> Files.newBufferedWriter(path,
-          StandardCharsets.UTF_8,
-          StandardOpenOption.CREATE,
-          StandardOpenOption.TRUNCATE_EXISTING,
-          StandardOpenOption.WRITE,
-          StandardOpenOption.DSYNC)
-        )
-        .setDefaultOptions(ConfigurationOptions.defaults())
-        .build();
-    } catch (IOException exception) {
-      throw new AssertionError("Unable to create configuration directory.", exception);
-    }
-  };
-
-  private static final ConcurrentMap<ConfigurationKey, Configuration<?, ?>> CONFIGURATIONS = new ConcurrentHashMap<>();
+  public static final @NonNull Function<ConfigurationKey, ConfigurationLoader<CommentedConfigurationNode>> HOCON_LOADER = key -> Configurations.createLoader(key, path -> HoconConfigurationLoader.builder()
+    .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
+    .setSink(() -> Files.newBufferedWriter(path, StandardCharsets.UTF_8, Configurations.SINK_OPTIONS))
+    .setDefaultOptions(ConfigurationOptions.defaults())
+    .build()
+  );
 
   /**
-   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader}, {@link Path}
-   * and {@code T} instance.
+   * Provides a function to make a general purpose {@link YAMLConfigurationLoader}
+   * using the input {@link ConfigurationKey}.
+   */
+  public static final @NonNull Function<ConfigurationKey, ConfigurationLoader<ConfigurationNode>> YAML_LOADER = key -> Configurations.createLoader(key, path -> YAMLConfigurationLoader.builder()
+    .setSource(() -> Files.newBufferedReader(path, StandardCharsets.UTF_8))
+    .setSink(() -> Files.newBufferedWriter(path, StandardCharsets.UTF_8, Configurations.SINK_OPTIONS))
+    .setDefaultOptions(ConfigurationOptions.defaults())
+    .build()
+  );
+
+  private static final ConcurrentMap<ConfigurationKey, Configuration<?, ?>> CONFIGURATIONS = new ConcurrentHashMap<>();
+  private static final OpenOption[] SINK_OPTIONS = new OpenOption[] {
+    StandardOpenOption.CREATE,
+    StandardOpenOption.TRUNCATE_EXISTING,
+    StandardOpenOption.WRITE,
+    StandardOpenOption.DSYNC
+  };
+
+  /**
+   * Loads a new virtual {@link Configuration} with the specified {@link ConfigurationKey}
+   * and {@link Class} instance type.
    *
-   * @param loaderSupplier The loader supplier
    * @param key The configuration key
-   * @param instance The instance
+   * @param instanceType The instance class
    * @param <T> The instance type
    * @param <N> The node type
    * @return The configuration
    */
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier, final ConfigurationKey key, final @NonNull T instance) {
-    return Configurations.load(loaderSupplier.apply(key), key, instance);
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> virtual(final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
+    return Configurations.loadConfiguration(ignored -> null, key, instanceType);
   }
 
   /**
-   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader}, {@link Path}
-   * and {@code T} instance.
+   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader},
+   * {@link ConfigurationKey} and {@link Class} instance type.
    *
    * @param loader The loader supplier
    * @param key The configuration key
-   * @param instance The instance
+   * @param instanceType The instance class
    * @param <T> The instance type
    * @param <N> The node type
    * @return The configuration
    */
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @Nullable ConfigurationLoader<N> loader, final @NonNull ConfigurationKey key, final @NonNull T instance) {
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @Nullable ConfigurationLoader<N> loader, final @NonNull ConfigurationKey key,
+                                                                                   final @NonNull Class<T> instanceType) {
+    return Configurations.loadConfiguration(ignored -> loader, key, instanceType);
+  }
+
+  /**
+   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader},
+   * {@link ConfigurationKey} and {@link Class} instance type.
+   *
+   * @param loaderSupplier The loader supplier
+   * @param key The configuration key
+   * @param instanceType The instance class
+   * @param <T> The instance type
+   * @param <N> The node type
+   * @return The configuration
+   */
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier,
+                                                                                   final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
+    return Configurations.loadConfiguration(loaderSupplier, key, instanceType);
+  }
+
+  private static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> loadConfiguration(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier,
+                                                                                                 final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
     return (Configuration<T, N>) Configurations.CONFIGURATIONS.computeIfAbsent(key, ignored -> {
       try {
-        final Configuration<T, N> configuration = new Configuration<>(key, instance, loader);
+        final Configuration<T, N> configuration = new Configuration<>(key, instanceType, loaderSupplier.apply(key));
         configuration.load();
         return configuration;
       } catch (final IOException | ObjectMappingException exception) {
         throw new AssertionError("Unable to load configuration.", exception);
       }
     });
+  }
+
+  private static <N extends ConfigurationNode, L extends AbstractConfigurationLoader<N>> L createLoader(final @NonNull ConfigurationKey key, final @NonNull Function<Path, L> loader) {
+    final Path path = key.getPath();
+    if (path == null) return null;
+
+    try {
+      Files.createDirectories(path.getParent());
+
+      return loader.apply(path);
+    } catch (final IOException exception) {
+      throw new AssertionError("Unable to create configuration directory.", exception);
+    }
   }
 }

--- a/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
+++ b/api/src/main/java/com/mineteria/ignite/api/config/Configurations.java
@@ -90,7 +90,7 @@ public final class Configurations {
   };
 
   /**
-   * Loads a new virtual {@link Configuration} with the specified {@link ConfigurationKey}
+   * Creates a new virtual {@link Configuration} with the specified {@link ConfigurationKey}
    * and {@link Class} instance type.
    *
    * @param key The configuration key
@@ -99,12 +99,12 @@ public final class Configurations {
    * @param <N> The node type
    * @return The configuration
    */
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> virtual(final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
-    return Configurations.loadConfiguration(ignored -> null, key, instanceType);
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> createVirtual(final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
+    return new Configuration<>(key, instanceType);
   }
 
   /**
-   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader},
+   * Gets or creates a new {@link Configuration} with the specified {@link ConfigurationLoader},
    * {@link ConfigurationKey} and {@link Class} instance type.
    *
    * @param loader The loader supplier
@@ -114,13 +114,13 @@ public final class Configurations {
    * @param <N> The node type
    * @return The configuration
    */
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @Nullable ConfigurationLoader<N> loader, final @NonNull ConfigurationKey key,
-                                                                                   final @NonNull Class<T> instanceType) {
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> getOrCreate(final @Nullable ConfigurationLoader<N> loader, final @NonNull ConfigurationKey key,
+                                                                                          final @NonNull Class<T> instanceType) {
     return Configurations.loadConfiguration(ignored -> loader, key, instanceType);
   }
 
   /**
-   * Loads a new {@link Configuration} with the specified {@link ConfigurationLoader},
+   * Gets or creates a new {@link Configuration} with the specified {@link ConfigurationLoader},
    * {@link ConfigurationKey} and {@link Class} instance type.
    *
    * @param loaderSupplier The loader supplier
@@ -130,8 +130,8 @@ public final class Configurations {
    * @param <N> The node type
    * @return The configuration
    */
-  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> load(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier,
-                                                                                   final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
+  public static <T, N extends ConfigurationNode> @NonNull Configuration<T, N> getOrCreate(final @NonNull Function<ConfigurationKey, ConfigurationLoader<N>> loaderSupplier,
+                                                                                          final @NonNull ConfigurationKey key, final @NonNull Class<T> instanceType) {
     return Configurations.loadConfiguration(loaderSupplier, key, instanceType);
   }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -15,9 +15,6 @@ repositories {
 dependencies {
   // API
   api(project(":api"))
-
-  // Mixins
-  api "org.spongepowered:mixin:0.8.2"
 }
 
 

--- a/example/src/main/java/com/mineteria/example/ExampleInfo.java
+++ b/example/src/main/java/com/mineteria/example/ExampleInfo.java
@@ -24,20 +24,32 @@
  */
 package com.mineteria.example;
 
-import ninja.leaping.configurate.objectmapping.Setting;
-import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+import com.mineteria.ignite.api.Blackboard;
+import com.mineteria.ignite.api.config.ConfigurationKey;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
-@ConfigSerializable
-public final class ExampleConfig {
-  @Setting(value = "test", comment = "Test configuration property.")
-  public boolean test = true;
+import java.nio.file.Path;
 
-  @Setting(value = "container", comment = "A test container.")
-  public TestContainer container = new TestContainer();
+public final class ExampleInfo {
+  private static final @MonotonicNonNull Path CONFIGS_PATH = Blackboard.getProperty(Blackboard.CONFIG_DIRECTORY_PATH);
 
-  @ConfigSerializable
-  public static class TestContainer {
-    @Setting(value = "foo", comment = "A test boolean in a container.")
-    public boolean foo = false;
+  private static @MonotonicNonNull Path EXAMPLE_PATH;
+  private static @MonotonicNonNull ConfigurationKey EXAMPLE_CONFIG;
+
+  public static @MonotonicNonNull Path getExamplePath() {
+    if (ExampleInfo.EXAMPLE_PATH != null) return ExampleInfo.EXAMPLE_PATH;
+    if (ExampleInfo.CONFIGS_PATH == null) return null;
+
+    return ExampleInfo.EXAMPLE_PATH = ExampleInfo.CONFIGS_PATH.resolve("example");
+  }
+
+  public static @NonNull ConfigurationKey getExampleConfig() {
+    if (ExampleInfo.EXAMPLE_CONFIG != null) return ExampleInfo.EXAMPLE_CONFIG;
+
+    final Path examplePath = ExampleInfo.getExamplePath();
+    if (examplePath == null) throw new IllegalStateException("Unable to locate example path.");
+
+    return ExampleInfo.EXAMPLE_CONFIG = ConfigurationKey.key("example", examplePath.resolve("example.conf"));
   }
 }

--- a/example/src/main/java/com/mineteria/example/ExampleMod.java
+++ b/example/src/main/java/com/mineteria/example/ExampleMod.java
@@ -26,31 +26,33 @@ package com.mineteria.example;
 
 import com.google.inject.Inject;
 import com.mineteria.ignite.api.Platform;
-import com.mineteria.ignite.api.config.path.ConfigPath;
+import com.mineteria.ignite.api.config.Configuration;
+import com.mineteria.ignite.api.config.Configurations;
 import com.mineteria.ignite.api.event.Subscribe;
 import com.mineteria.ignite.api.event.platform.PlatformInitializeEvent;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import java.nio.file.Path;
-
-@SuppressWarnings("UnstableApiUsage")
 public final class ExampleMod {
   private final Logger logger;
   private final Platform platform;
-  private final Path configurationPath;
 
   @Inject
   public ExampleMod(final Logger logger,
-                    final Platform platform,
-                    final @ConfigPath Path configurationPath) {
+                    final Platform platform) {
     this.logger = logger;
     this.platform = platform;
-    this.configurationPath = configurationPath;
   }
 
   @Subscribe
   public void onInitialize(final @NonNull PlatformInitializeEvent event) {
-    this.logger.info("Hello Initialization!");
+    this.logger.info("Hello Example!");
+
+    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.load(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
+    final ExampleConfig config = configWrapper.getInstance();
+    if (config != null) {
+      this.logger.info("Foo is set to: " + (config.container.foo ? "Enabled" : "Disabled"));
+    }
   }
 }

--- a/example/src/main/java/com/mineteria/example/ExampleMod.java
+++ b/example/src/main/java/com/mineteria/example/ExampleMod.java
@@ -49,7 +49,7 @@ public final class ExampleMod {
   public void onInitialize(final @NonNull PlatformInitializeEvent event) {
     this.logger.info("Hello Example!");
 
-    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.load(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
+    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.getOrCreate(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
     final ExampleConfig config = configWrapper.getInstance();
     if (config != null) {
       this.logger.info("Foo is set to: " + (config.container.foo ? "Enabled" : "Disabled"));

--- a/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
+++ b/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
@@ -25,9 +25,8 @@
 package com.mineteria.example.mixin.plugins;
 
 import com.mineteria.example.ExampleConfig;
-import com.mineteria.ignite.api.Blackboard;
+import com.mineteria.example.ExampleInfo;
 import com.mineteria.ignite.api.config.Configuration;
-import com.mineteria.ignite.api.config.ConfigurationKey;
 import com.mineteria.ignite.api.config.Configurations;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -40,11 +39,6 @@ import java.util.List;
 import java.util.Set;
 
 public final class CorePlugin implements IMixinConfigPlugin {
-  private static final ConfigurationKey EXAMPLE_KEY = ConfigurationKey.key("example", Blackboard.getProperty(Blackboard.CONFIG_DIRECTORY_PATH)
-    .resolve("example")
-    .resolve("example.conf")
-  );
-
   @Override
   public void onLoad(final @NonNull String mixinPackage) {
   }
@@ -56,9 +50,11 @@ public final class CorePlugin implements IMixinConfigPlugin {
 
   @Override
   public final boolean shouldApplyMixin(final @NonNull String targetClassName, final @NonNull String mixinClassName) {
-    final Configuration<ExampleConfig, CommentedConfigurationNode> config = Configurations.load(Configurations.HOCON_LOADER, CorePlugin.EXAMPLE_KEY, new ExampleConfig());
+    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.load(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
+    final ExampleConfig config = configWrapper.getInstance();
+    if (config == null) return false;
 
-    return config.getInstance().test;
+    return config.test;
   }
 
   @Override

--- a/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
+++ b/example/src/main/java/com/mineteria/example/mixin/plugins/CorePlugin.java
@@ -50,11 +50,13 @@ public final class CorePlugin implements IMixinConfigPlugin {
 
   @Override
   public final boolean shouldApplyMixin(final @NonNull String targetClassName, final @NonNull String mixinClassName) {
-    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.load(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
+    final Configuration<ExampleConfig, CommentedConfigurationNode> configWrapper = Configurations.getOrCreate(Configurations.HOCON_LOADER, ExampleInfo.getExampleConfig(), ExampleConfig.class);
     final ExampleConfig config = configWrapper.getInstance();
-    if (config == null) return false;
+    if (config != null) {
+      return config.test;
+    }
 
-    return config.test;
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Previously, configuration object mapping did not work quite right. It wouldn't save configurations from object mapping that contained other serialized classes. This was most likely due to duplicated configuration instances, which in this PR is fixed by keeping the configuration instance contained within the `ObjectMapper.BoundInstance`. This also updates the example to contain a test of this in action.