### PR TITLE
Only initialize one primary mixin container

### DIFF
--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
@@ -154,7 +154,7 @@ public final class EmberMixinService implements IMixinService, IClassProvider, I
 
   @Override
   public Collection<String> getPlatformAgents() {
-    return Collections.singletonList("org.spongepowered.asm.launch.platform.MixinPlatformAgentDefault");
+    return Collections.emptyList();
   }
 
   @Override


### PR DESCRIPTION
The default agent is already added to the list of platform agents, so it was preparing the primary container twice. 