### PR TITLE
Fix access widener transformer not providing the widened ClassNode

### DIFF
--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberTransformer.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberTransformer.java
@@ -104,8 +104,9 @@ public final class EmberTransformer {
       return input;
     }
 
+    ClassNode node = new ClassNode(IgniteConstants.ASM_VERSION);
+
     final Type type = Type.getObjectType(internalName);
-    final ClassNode node = new ClassNode(IgniteConstants.ASM_VERSION);
     if(input.length > 0) {
       final ClassReader reader = new ClassReader(input);
       reader.accept(node, 0);
@@ -123,7 +124,11 @@ public final class EmberTransformer {
           // If the transformer should not transform the class, skip it.
           if(!service.shouldTransform(type, node)) continue;
           // Attempt to transform the class.
-          transformed |= service.transform(type, node, phase);
+          final ClassNode transformedNode = service.transform(type, node, phase);
+          if(transformedNode != null) {
+            node = transformedNode;
+            transformed = true;
+          }
         } catch(final Throwable throwable) {
           Logger.error(throwable, "Failed to transform {} with {}", type.getClassName(), service.getClass().getName());
         }

--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/TransformerService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/TransformerService.java
@@ -25,6 +25,7 @@
 package space.vectrix.ignite.launch.ember;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 
@@ -71,14 +72,14 @@ public interface TransformerService {
 
   /**
    * Attempts to transform a class, with the given {@link Type}, {@link ClassNode}
-   * and {@link TransformPhase} and returns {@code true} if modifications were
-   * made, otherwise returns {@code false}.
+   * and {@link TransformPhase} and returns the {@link ClassNode} if modifications were
+   * made, otherwise returns {@code null}.
    *
    * @param type the type
    * @param node the class node
    * @param phase the transform phase
-   * @return whether the class was transformed
-   * @since 1.0.0
+   * @return whether the class node if the class was transformed
+   * @since 1.0.2
    */
-  boolean transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable;
+  @Nullable ClassNode transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable;
 }

--- a/launcher/src/main/java/space/vectrix/ignite/launch/transformer/AccessTransformerImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/transformer/AccessTransformerImpl.java
@@ -83,7 +83,7 @@ public final class AccessTransformerImpl implements TransformerService {
   }
 
   @Override
-  public boolean transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable {
+  public @NotNull ClassNode transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable {
     final ClassNode widened = new ClassNode(IgniteConstants.ASM_VERSION);
     widened.accept(node);
 
@@ -103,6 +103,6 @@ public final class AccessTransformerImpl implements TransformerService {
     node.interfaces.clear();
 
     widened.accept(visitor);
-    return true;
+    return widened;
   }
 }

--- a/launcher/src/main/java/space/vectrix/ignite/launch/transformer/MixinTransformerImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/transformer/MixinTransformerImpl.java
@@ -25,6 +25,7 @@
 package space.vectrix.ignite.launch.transformer;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
@@ -82,14 +83,14 @@ public final class MixinTransformerImpl implements TransformerService {
   }
 
   @Override
-  public boolean transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable {
+  public @Nullable ClassNode transform(final @NotNull Type type, final @NotNull ClassNode node, final @NotNull TransformPhase phase) throws Throwable {
     // Generate the class if it is synthetic through mixin.
     if(this.shouldGenerateClass(type)) {
-      return this.generateClass(type, node);
+      return this.generateClass(type, node) ? node : null;
     }
 
     // Transform the class through mixin.
-    return this.transformer.transformClass(MixinEnvironment.getCurrentEnvironment(), type.getClassName(), node);
+    return this.transformer.transformClass(MixinEnvironment.getCurrentEnvironment(), type.getClassName(), node) ? node : null;
   }
 
   /**


### PR DESCRIPTION
When the transformers were applied, the updated ClassNode would not be given to the other transformers and class loader. This fixes that problem while also fixing only one transformer per class getting applied.