### PR TITLE
Support loading game and mods from classpath for dev configurations

### DIFF
--- a/api/src/main/java/space/vectrix/ignite/Blackboard.java
+++ b/api/src/main/java/space/vectrix/ignite/Blackboard.java
@@ -49,6 +49,10 @@ public final class Blackboard {
   public static final BlackboardMap.@NotNull Key<String> GAME_TARGET = key("ignite.target", String.class, "org.bukkit.craftbukkit.Main");
   public static final BlackboardMap.@NotNull Key<Path> GAME_LIBRARIES = key("ignite.libraries", Path.class, Paths.get("./libraries"));
   public static final BlackboardMap.@NotNull Key<Path> MODS_DIRECTORY = key("ignite.mods", Path.class, Paths.get("./mods"));
+
+  // not strictly a startup flag
+  public static final BlackboardMap.@NotNull Key<Boolean> IS_CLASS_PATH = key("isGameClasspath", Boolean.class, false);
+
   // formatting:on
 
   /**

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   id("ignite.launcher-conventions")
+  id("ignite.publish-conventions")
 }
 
 dependencies {

--- a/launcher/src/main/java/space/vectrix/ignite/IgniteBootstrap.java
+++ b/launcher/src/main/java/space/vectrix/ignite/IgniteBootstrap.java
@@ -141,16 +141,18 @@ public final class IgniteBootstrap {
 
     Logger.info("Preparing the game...");
 
-    // Add the game.
-    final Path gameJar = Blackboard.raw(Blackboard.GAME_JAR);
-    try {
-      IgniteAgent.addJar(gameJar);
+    // Add the game, only if the classes aren't already in the classpath.
+    if(!Blackboard.raw(Blackboard.IS_CLASS_PATH)) {
+      final Path gameJar = Blackboard.raw(Blackboard.GAME_JAR);
+      try {
+        IgniteAgent.addJar(gameJar);
 
-      Logger.trace("Added game jar: {}", gameJar);
-    } catch(final IOException exception) {
-      Logger.error(exception, "Failed to resolve game jar: {}", gameJar);
-      System.exit(1);
-      return;
+        Logger.trace("Added game jar: {}", gameJar);
+      } catch (final IOException exception) {
+        Logger.error(exception, "Failed to resolve game jar: {}", gameJar);
+        System.exit(1);
+        return;
+      }
     }
 
     // Add the game libraries.

--- a/launcher/src/main/java/space/vectrix/ignite/agent/IgniteAgent.java
+++ b/launcher/src/main/java/space/vectrix/ignite/agent/IgniteAgent.java
@@ -80,7 +80,8 @@ public final class IgniteAgent {
       return;
     }
 
-    throw new IllegalStateException("Unable to addJar for '" + jar.getName() + "'.");
+    // assume it's run with no agent, just ignore...
+    // throw new IllegalStateException("Unable to addJar for '" + jar.getName() + "'.");
   }
 
   /**

--- a/launcher/src/main/java/space/vectrix/ignite/game/ClasspathGameLocator.java
+++ b/launcher/src/main/java/space/vectrix/ignite/game/ClasspathGameLocator.java
@@ -1,0 +1,97 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.ignite.game;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import space.vectrix.ignite.Blackboard;
+import space.vectrix.ignite.IgniteBootstrap;
+
+/**
+ * Provides a game locator for that uses the classpath.
+ * Also enables mod loading via classpath.
+ *
+ * @author Flowey
+ * @since 1.0.2
+ */
+public final class ClasspathGameLocator implements GameLocatorService {
+  private ClasspathGameProvider provider;
+
+  @Override
+  public @NotNull String id() {
+    return "classpath";
+  }
+
+  @Override
+  public @NotNull String name() {
+    return "Dev Class Path Loader";
+  }
+
+  @Override
+  public int priority() {
+    return 100;
+  }
+
+  @Override
+  public boolean shouldApply() {
+    // we can't afford to load the class here, so just assume it's valid
+    return true;
+  }
+
+  @Override
+  public void apply(final @NotNull IgniteBootstrap bootstrap) throws Throwable {
+    // Create the game provider.
+    if (this.provider == null) {
+      this.provider = this.createProvider();
+    }
+
+    Blackboard.compute(Blackboard.IS_CLASS_PATH, () -> true);
+  }
+
+  @Override
+  public @NotNull GameProvider locate() {
+    return this.provider;
+  }
+
+  private ClasspathGameProvider createProvider() {
+    return new ClasspathGameProvider();
+  }
+
+  /* package */ static final class ClasspathGameProvider implements GameProvider {
+    /* package */ ClasspathGameProvider() {
+    }
+
+    @Override
+    public @NotNull Stream<Path> gameLibraries() {
+      return Stream.empty(); // should be in classpath...
+    }
+
+    @Override
+    public @NotNull Path gamePath() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/launcher/src/main/java/space/vectrix/ignite/launch/LaunchImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/LaunchImpl.java
@@ -121,7 +121,7 @@ public final class LaunchImpl implements LaunchService {
     return () -> {
       final Path gameJar = Blackboard.raw(Blackboard.GAME_JAR);
       final String gameTarget = Blackboard.raw(Blackboard.GAME_TARGET);
-      if(gameJar != null && Files.exists(gameJar)) {
+      if(Blackboard.raw(Blackboard.IS_CLASS_PATH) || (gameJar != null && Files.exists(gameJar))) {
         // Invoke the main method.
         Class.forName(gameTarget, true, loader)
           .getMethod("main", String[].class)
@@ -171,7 +171,12 @@ public final class LaunchImpl implements LaunchService {
             }
 
             try {
-              if(resource.path().toAbsolutePath().normalize().equals(Paths.get(url.toURI()).toAbsolutePath().normalize())) {
+              final Path path = resource.path();
+              if(path == null) {
+                return Optional.empty();
+              }
+
+              if(path.toAbsolutePath().normalize().equals(Paths.get(url.toURI()).toAbsolutePath().normalize())) {
                 return Optional.ofNullable(resource.manifest());
               }
             } catch(final URISyntaxException exception) {

--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinContainer.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinContainer.java
@@ -25,10 +25,13 @@
 package space.vectrix.ignite.launch.ember;
 
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleURI;
 import org.spongepowered.asm.launch.platform.container.ContainerHandleVirtual;
+import org.spongepowered.asm.launch.platform.container.IContainerHandle;
 
 /**
  * Represents the root container.
@@ -56,6 +59,15 @@ public final class EmberMixinContainer extends ContainerHandleVirtual {
    */
   public void addResource(final @NotNull String name, final @NotNull Path path) {
     this.add(new ResourceContainer(name, path));
+  }
+
+  /**
+   * Adds a classpath resource to this container.
+   *
+   * @since 1.0.2
+   */
+  public void addClassPath() {
+    this.add(new ClassPathResourceContainer());
   }
 
   /**
@@ -95,6 +107,23 @@ public final class EmberMixinContainer extends ContainerHandleVirtual {
     @Override
     public @NotNull String toString() {
       return "ResourceContainer{name=" + this.name + ", path=" + this.path + "}";
+    }
+  }
+
+  static class ClassPathResourceContainer implements IContainerHandle {
+    @Override
+    public String getAttribute(final String s) {
+      return null;
+    }
+
+    @Override
+    public Collection<IContainerHandle> getNestedContainers() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      return obj instanceof ClassPathResourceContainer;
     }
   }
 }

--- a/launcher/src/main/java/space/vectrix/ignite/launch/transformer/AccessTransformerImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/transformer/AccessTransformerImpl.java
@@ -26,9 +26,9 @@ package space.vectrix.ignite.launch.transformer;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import net.fabricmc.accesswidener.AccessWidener;
 import net.fabricmc.accesswidener.AccessWidenerClassVisitor;
 import net.fabricmc.accesswidener.AccessWidenerReader;
@@ -53,12 +53,12 @@ public final class AccessTransformerImpl implements TransformerService {
   /**
    * Adds a widener to this transformer.
    *
-   * @param path the configuration path
+   * @param input a stream that can be used to read the widener
    * @throws IOException if an error occurs while reading the widener
    * @since 1.0.0
    */
-  public void addWidener(final @NotNull Path path) throws IOException {
-    try(final BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
+  public void addWidener(final @NotNull InputStream input) throws IOException {
+    try(final BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
       this.widenerReader.read(reader);
     }
   }

--- a/launcher/src/main/java/space/vectrix/ignite/mod/ModClassPathResourceImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/mod/ModClassPathResourceImpl.java
@@ -24,54 +24,61 @@
  */
 package space.vectrix.ignite.mod;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.jar.Manifest;
-import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
 
 /**
- * Represents a mod resource.
+ * Represents a mod resource that may not be resolved.
  *
- * @author vectrix
- * @since 1.0.0
+ * @author Flowey
+ * @since 1.0.2
  */
-@ApiStatus.NonExtendable
-public interface ModResource {
-  /**
-   * Returns the resource locator type.
-   *
-   * @return the resource locator type
-   * @since 1.0.0
-   */
-  @NotNull String locator();
+public final class ModClassPathResourceImpl implements ModResource {
+  private final String locator;
 
-  /**
-   * Returns the resource path.
-   *
-   * @return the resource path
-   * @since 1.0.0
-   */
-  @Nullable Path path();
+  /* package */ ModClassPathResourceImpl(final @NotNull String locator) {
+    this.locator = locator;
+  }
 
-  /**
-   * Returns the {@link Manifest} for this resource.
-   *
-   * @return the manifest
-   * @since 1.0.0
-   */
-  @UnknownNullability Manifest manifest();
+  @Override
+  public @NotNull String locator() {
+    return this.locator;
+  }
 
-  /**
-   * Searches for a file within this resource.
-   *
-   * @param name The path/name of the resource
-   * @return an {@link InputStream} corresponding to the resource
-   * @throws IOException if the underlying operation fails
-   * @since 1.0.2
-   */
-  @Nullable InputStream loadResource(String name) throws IOException;
+  @Override
+  public @Nullable Path path() {
+    return null;
+  }
+
+  @Override
+  public @Nullable Manifest manifest() {
+    return null;
+  }
+
+  @Override
+  public @Nullable InputStream loadResource(final String path) {
+    return ClassLoader.getSystemClassLoader().getResourceAsStream(path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.locator);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(this == other) return true;
+    if(!(other instanceof ModClassPathResourceImpl)) return false;
+    final ModClassPathResourceImpl that = (ModClassPathResourceImpl) other;
+    return Objects.equals(this.locator, that.locator);
+  }
+
+  @Override
+  public String toString() {
+    return "ModClassPathResourceImpl{locator='" + this.locator + "}";
+  }
 }

--- a/launcher/src/main/java/space/vectrix/ignite/mod/ModResourceImpl.java
+++ b/launcher/src/main/java/space/vectrix/ignite/mod/ModResourceImpl.java
@@ -25,10 +25,11 @@
 package space.vectrix.ignite.mod;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,8 +45,6 @@ public final class ModResourceImpl implements ModResource {
   private final String locator;
   private final Path path;
   private final Manifest manifest;
-
-  private FileSystem fileSystem;
 
   /* package */ ModResourceImpl(final @NotNull String locator,
                                 final @NotNull Path path,
@@ -71,16 +70,13 @@ public final class ModResourceImpl implements ModResource {
   }
 
   @Override
-  public @NotNull FileSystem fileSystem() {
-    if(this.fileSystem == null) {
-      try {
-        this.fileSystem = FileSystems.newFileSystem(this.path(), this.getClass().getClassLoader());
-      } catch(final IOException exception) {
-        throw new RuntimeException(exception);
-      }
-    }
+  public @Nullable InputStream loadResource(final String name) throws IOException {
+    final JarFile jarFile = new JarFile(this.path.toFile());
+    final JarEntry entry = jarFile.getJarEntry(name);
+    if (entry == null)
+      return null;
 
-    return this.fileSystem;
+    return jarFile.getInputStream(entry);
   }
 
   @Override

--- a/launcher/src/main/java/space/vectrix/ignite/mod/ModResourceLoader.java
+++ b/launcher/src/main/java/space/vectrix/ignite/mod/ModResourceLoader.java
@@ -27,11 +27,8 @@ package space.vectrix.ignite.mod;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import org.jetbrains.annotations.NotNull;
 import org.tinylog.Logger;
 import space.vectrix.ignite.util.IgniteConstants;
@@ -57,12 +54,9 @@ public final class ModResourceLoader {
         continue;
       }
 
-      final Path resourcePath = resource.path();
-      try(final JarFile jarFile = new JarFile(resourcePath.toFile())) {
-        final JarEntry jarEntry = jarFile.getJarEntry(IgniteConstants.MOD_CONFIG);
-        if(jarEntry == null) continue;
+      try(final InputStream inputStream = resource.loadResource(IgniteConstants.MOD_CONFIG)) {
+        if(inputStream == null) continue;
 
-        final InputStream inputStream = jarFile.getInputStream(jarEntry);
         final ModConfig config = IgniteConstants.GSON.fromJson(new InputStreamReader(inputStream), ModConfig.class);
 
         containers.add(new ModContainerImpl(Logger.tag(config.id()), resource, config));

--- a/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.game.GameLocatorService
+++ b/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.game.GameLocatorService
@@ -2,3 +2,4 @@ space.vectrix.ignite.game.SpigotGameLocator
 space.vectrix.ignite.game.PaperGameLocator
 space.vectrix.ignite.game.LegacyPaperGameLocator
 space.vectrix.ignite.game.DummyGameLocator
+space.vectrix.ignite.game.ClasspathGameLocator


### PR DESCRIPTION
## Motivation
When doing development, it's often beneficial to be able to easily run the server in a development environment (mojmapped everything). This enables features like class/mixin hotswapping.

This pull request implements loading mods and the target game from the classpath, which can be set to contain the mod classes and a mojmap server.

I have done some preliminary testing, and it doesn't seem to break other mod loading options. 

## Dev Env Setup
With this PR, developers can change the following to set up a sane environment:
Add the following dependencies to the runtime classpath:
```kts
implementation("space.vectrix.ignite:ignite-launcher:$igniteVersion") // this needs to be published to maven
implementation("io.papermc.paper:paper-server:userdev-$paperVersion")
implementation("com.lmax:disruptor:3.4.2") // I don't know why this is needed
```

For IntelliJ, add an application configuration with:
- Classpath: module `project-name.main`
- VM options (you may need to enable adding vm options with modify options dropdown): `-Dignite.locator=classpath`
- Main class: `space.vectrix.ignite.IgniteBootstrap`
- Program args: `-nogui`
- Working dir: `$PROJECT/run/`

Bonus: mixin hotswap works as expected, see the fabric guide