### PR TITLE
Bump MixinService max compat to Java 22

### DIFF
--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
@@ -180,7 +180,7 @@ public final class EmberMixinService implements IMixinService, IClassProvider, I
 
   @Override
   public MixinEnvironment.CompatibilityLevel getMaxCompatibilityLevel() {
-    return MixinEnvironment.CompatibilityLevel.JAVA_17;
+    return MixinEnvironment.CompatibilityLevel.JAVA_22;
   }
   //</editor-fold>
 


### PR DESCRIPTION
Bumps the max compatibility level to Java 22 for Mixin.