### PR TITLE
Fix issues using `DummyGameLocator` with libraries

### DIFF
--- a/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
+++ b/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
@@ -26,7 +26,6 @@ package space.vectrix.ignite.game;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
+++ b/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
@@ -93,7 +93,7 @@ public final class DummyGameLocator implements GameLocatorService {
         // will be closed as soon as we exit the try-catch block.
         libraries = stream
           .filter(Files::isRegularFile)
-          .filter(path -> path.getFileName().endsWith(".jar"))
+          .filter(path -> path.toString().endsWith(".jar"))
           .collect(Collectors.toList());
       } catch(final Throwable throwable) {
         return Stream.empty();

--- a/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
+++ b/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
@@ -26,6 +26,9 @@ package space.vectrix.ignite.game;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.tinylog.Logger;
@@ -84,13 +87,20 @@ public final class DummyGameLocator implements GameLocatorService {
     @Override
     public @NotNull Stream<Path> gameLibraries() {
       final Path libraryPath = Blackboard.raw(Blackboard.GAME_LIBRARIES);
+      final List<Path> libraries;
+      
       try(final Stream<Path> stream = Files.walk(libraryPath)) {
-        return stream
+        // We must .collect() to a list and re-stream() as Stream is AutoClosable, and thus
+        // will be closed as soon as we exit the try-catch block.
+        libraries = stream
           .filter(Files::isRegularFile)
-          .filter(path -> path.getFileName().endsWith(".jar"));
+          .filter(path -> path.getFileName().endsWith(".jar"))
+          .collect(Collectors.toList());
       } catch(final Throwable throwable) {
         return Stream.empty();
       }
+
+      return libraries.stream();
     }
 
     @Override

--- a/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
+++ b/launcher/src/main/java/space/vectrix/ignite/game/DummyGameLocator.java
@@ -87,7 +87,7 @@ public final class DummyGameLocator implements GameLocatorService {
     public @NotNull Stream<Path> gameLibraries() {
       final Path libraryPath = Blackboard.raw(Blackboard.GAME_LIBRARIES);
       final List<Path> libraries;
-      
+
       try(final Stream<Path> stream = Files.walk(libraryPath)) {
         // We must .collect() to a list and re-stream() as Stream is AutoClosable, and thus
         // will be closed as soon as we exit the try-catch block.


### PR DESCRIPTION
**Issue #1: `DummyGameLocator#gameLibraries()` returns a closed `Stream`**

As `Stream` is `AutoCloseable`, the stream returned by `DummyGameLocator`'s `gameLibraries()` method was getting closed immediately after the try-catch block. This resulted in the following error:

```
[11:00:03] [main/INFO]: Preparing the game...
Exception in thread "main" java.lang.IllegalStateException
	at java.base/java.nio.file.FileTreeIterator.hasNext(FileTreeIterator.java:102)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:132)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at space.vectrix.ignite.IgniteBootstrap.run(IgniteBootstrap.java:157)
	at space.vectrix.ignite.IgniteBootstrap.main(IgniteBootstrap.java:74)
```

This `IllegalStateException` is being thrown here: https://github.com/JetBrains/jdk8u_jdk/blob/master/src/share/classes/java/nio/file/FileTreeIterator.java#L102-L103, as the stream is already closed.

**Issue #2: Incorrect `.jar` extension check**

`.endsWith()` on `Path` has some interesting semantics, and doesn't just match a suffix on the file name like we're expecting it to. Changing to `.toString().endsWith()` fixes this.