### PR TITLE
Fix paper remapping failing due to missing `CodeSource`

### DIFF
--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/EmberMixinService.java
@@ -29,8 +29,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
-import java.util.jar.Manifest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.tree.ClassNode;
@@ -226,10 +224,10 @@ public final class EmberMixinService implements IMixinService, IClassProvider, I
     final String canonicalName = name.replace('/', '.');
     final String internalName = name.replace('.', '/');
 
-    final @Nullable Map.Entry<byte[], Manifest> entry = loader.classData(canonicalName, TransformPhase.MIXIN);
+    final @Nullable EmberClassLoader.ClassData entry = loader.classData(canonicalName, TransformPhase.MIXIN);
     if(entry == null) throw new ClassNotFoundException(canonicalName);
 
-    return mixinTransformer.classNode(canonicalName, internalName, entry.getKey());
+    return mixinTransformer.classNode(canonicalName, internalName, entry.data());
   }
   //</editor-fold>
 

--- a/launcher/src/main/java/space/vectrix/ignite/launch/ember/ResourceConnection.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/ember/ResourceConnection.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.security.CodeSource;
 import java.util.function.Function;
 import java.util.jar.Manifest;
 import org.jetbrains.annotations.NotNull;
@@ -37,11 +38,15 @@ import org.jetbrains.annotations.Nullable;
   private final URLConnection connection;
   private final InputStream stream;
   private final Function<URLConnection, Manifest> manifestFunction;
+  private final Function<URLConnection, CodeSource> sourceFunction;
 
-  /* package */ ResourceConnection(final @NotNull URL url, final @NotNull Function<@NotNull URLConnection, @Nullable Manifest> manifestLocator) throws IOException {
+  /* package */ ResourceConnection(final @NotNull URL url,
+                                   final @NotNull Function<@NotNull URLConnection, @Nullable Manifest> manifestLocator,
+                                   final @NotNull Function<@NotNull URLConnection, @Nullable CodeSource> sourceLocator) throws IOException {
     this.connection = url.openConnection();
     this.stream = this.connection.getInputStream();
     this.manifestFunction = manifestLocator;
+    this.sourceFunction = sourceLocator;
   }
 
   /* package */ int contentLength() {
@@ -54,6 +59,10 @@ import org.jetbrains.annotations.Nullable;
 
   /* package */ @Nullable Manifest manifest() {
     return this.manifestFunction.apply(this.connection);
+  }
+
+  /* package */ @Nullable CodeSource source() {
+    return this.sourceFunction.apply(this.connection);
   }
 
   @Override


### PR DESCRIPTION
Correctly defines `CodeSource`s to classes loaded in the `EmberClassLoader` fixing the missing `CodeSource` Paper needed to remap plugins (among other things).